### PR TITLE
修复位数判断错误及长度定义不规范的情况

### DIFF
--- a/windows/project/part01/common/lua.h
+++ b/windows/project/part01/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -31,11 +32,11 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 
 
-#if defined(LLONG_MAX)
-#define LUA_INTEGER long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
 #define LUA_NUMBER double
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t 
 #define LUA_NUMBER float 
 #endif 
 

--- a/windows/project/part02/common/lua.h
+++ b/windows/project/part02/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -31,11 +32,11 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 
 
-#if defined(LLONG_MAX)
-#define LUA_INTEGER long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
 #define LUA_NUMBER double
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t 
 #define LUA_NUMBER float 
 #endif 
 

--- a/windows/project/part03/common/lua.h
+++ b/windows/project/part03/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,11 +35,11 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 
 
-#if defined(LLONG_MAX)
-#define LUA_INTEGER long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
 #define LUA_NUMBER double
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t 
 #define LUA_NUMBER float 
 #endif 
 

--- a/windows/project/part04/common/lua.h
+++ b/windows/project/part04/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -35,15 +36,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 
 
-#if defined(LLONG_MAX)
-#define LUA_INTEGER long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t 
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 #endif 
 
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part05/common/lua.h
+++ b/windows/project/part05/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%ld"
 #define LUA_NUMBER_FORMAT "%lf"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t 
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part06/common/lua.h
+++ b/windows/project/part06/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%lld"
 #define LUA_NUMBER_FORMAT "%.14g"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part07/common/lua.h
+++ b/windows/project/part07/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%lld"
 #define LUA_NUMBER_FORMAT "%.14g"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part08/common/lua.h
+++ b/windows/project/part08/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%lld"
 #define LUA_NUMBER_FORMAT "%.14g"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part09/common/lua.h
+++ b/windows/project/part09/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%lld"
 #define LUA_NUMBER_FORMAT "%.14g"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part10/common/lua.h
+++ b/windows/project/part10/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%lld"
 #define LUA_NUMBER_FORMAT "%.14g"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 

--- a/windows/project/part11/common/lua.h
+++ b/windows/project/part11/common/lua.h
@@ -23,6 +23,7 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #include <stdarg.h>
 #include <setjmp.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdbool.h>
@@ -34,14 +35,16 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 #include <math.h>
 #include <stdint.h>
 
-#if defined(LLONG_MAX) 
-#define LUA_INTEGER long long
+#if SIZE_MAX != 0xffffffffui32
+#define LUA_INTEGER int64_t
+#define LUA_UNSIGNED uint64_t
 #define LUA_NUMBER double
 
 #define LUA_INTEGER_FORMAT "%lld"
 #define LUA_NUMBER_FORMAT "%.14g"
 #else
-#define LUA_INTEGER int 
+#define LUA_INTEGER int32_t
+#define LUA_UNSIGNED uint32_t
 #define LUA_NUMBER float 
 
 #define LUA_INTEGER_FORMAT "%d"
@@ -50,7 +53,6 @@ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 
 #define LUA_ENV "_ENV"
 #define LUA_LOADED "_LOADED"
-#define LUA_UNSIGNED unsigned LUA_INTEGER 
 #define lua_assert(c) ((void)0)
 #define check_exp(c, e) (lua_assert(c), e)
 


### PR DESCRIPTION
问题详情：LLONG_MAX宏始终有定义，将使得任何情况下都会走64位定义，32位定义将成为永远无法使用的代码，此处疑似有问题。另外part1~4使用了long类型定义64位，这是错误的定义方式。标准做法是32位 `int32_t` / `uint32_t`，64位 `int64_t` / `uint64_t`